### PR TITLE
Events in DOM handlers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -259,20 +259,20 @@ Component.prototype =
     },
 
     /**
-     * Handler for each distinc event from decl
+     * Handler for each distinct event from decl
      * @private
      * @param  {Event} e
      * @return {jBlocks.Component}
      */
     __handlerDomEvents: function(e) {
-        this.__forEachEvent(function(event, selector, callbackName) {
+        this.__forEachEvent(function(_, selector, callbackName) {
             if (selector) {
                 var node = this.node.querySelector(selector);
                 if (this.__contains(node, e.target)) {
-                    this.__tryCall(callbackName);
+                    this.__tryCall(callbackName, e);
                 }
             } else {
-                this.__tryCall(callbackName);
+                this.__tryCall(callbackName, e);
             }
         });
     },
@@ -284,8 +284,10 @@ Component.prototype =
      * @return {*}
      */
     __tryCall: function(method) {
+        var args = [].slice.call(arguments, 1);
+
         try {
-            return this[method]();
+            return this[method].apply(this, args);
         } catch (e) {
             throw new Error(e.message + '. Check out ' + method);
         }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build": "./node_modules/.bin/webpack index.browser.js jblocks.js",
-    "test": "node node_modules/.bin/gulp test",
+    "test": "node_modules/.bin/gulp test",
     "doc": "./node_modules/.bin/jsdoc ./lib/index.js -t ./node_modules/ink-docstrap/template -c ./jsdoc.json -d doc -R README.md"
   },
   "repository": {

--- a/tests/specs.js
+++ b/tests/specs.js
@@ -198,7 +198,17 @@ describe('jblocks', function() {
 
                     baz.clickedOnBar.should.eql(true);
                     baz.clickedOnFoo.should.eql(false);
-                })
+                });
+                it('should pass event as an argument to the handler', function() {
+                    var rootNode = document.querySelector('.js-baz')
+                    var counter = jBlocks.get(rootNode);
+                    var _onClickSelf = counter.onClickSelf;
+                    counter.onClickSelf = function(e) {
+                        e.target.should.be.eql(rootNode);
+                    }
+                    rootNode.click();
+                    counter.onClickSelf = _onClickSelf;
+                });
             });
         });
     });


### PR DESCRIPTION
Closes #23

Now you can use `e` in DOM events handlers which you declare within the `events` section. It's super annoying to not have it as everybody got used to.